### PR TITLE
pref: 搜索完成后滚动条到顶部

### DIFF
--- a/src/components/SearchSongs.vue
+++ b/src/components/SearchSongs.vue
@@ -10,7 +10,7 @@
                         <el-button slot="append" icon="el-icon-search" @click="getList">搜索</el-button>
                     </el-autocomplete>
                 </div>
-                <div class="bbbug_main_right_song_list_search" v-loading="bbbug_loading">
+                <div ref="searchBox" class="bbbug_main_right_song_list_search" v-loading="bbbug_loading">
                     <div class="bbbug_scroll">
                         <div class="bbbug_main_right_song_item_title" v-if="isHots">本周点歌热门歌曲推荐</div>
                         <div class="bbbug_main_right_song_item" v-for="(item, index) in list" v-loading="item.loading">
@@ -162,6 +162,7 @@
                     success(res) {
                         that.bbbug_loading = false;
                         that.list = res.data;
+                        that.$refs.searchBox.scrollTop = 0;
                     },
                     error(res) {
                         that.bbbug_loading = false;


### PR DESCRIPTION
更好用户体验，无法测试😅
如果无效可以将 that.$refs.searchBox.scrollTop = 0;
替换为
document.getElementsByClassName('bbbug_main_right_song_list_search')[0].scrollTop = 0