### PR TITLE
fix: 使用websocket API更新歌曲数量图标

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2418,7 +2418,6 @@
                                 //     that.addSystemMessage(obj.content);
                                 break;
                             case 'addSong':
-                                console.log('add', obj);
                                 that.sendAppEvent('addSong', {
                                     data: obj
                                 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -2260,10 +2260,10 @@
                         }
                         obj.time = parseInt(new Date().valueOf() / 1000);
 
-						// 更新当前歌曲数量
-						if(!isNaN(obj.count)) {
-							that.songCount = obj.count;
-						}
+                        // 更新当前歌曲数量
+                        if(!isNaN(obj.count)) {
+                            that.songCount = obj.count;
+                        }
 
                         switch (obj.type) {
                             case 'preload':
@@ -2418,7 +2418,7 @@
                                 //     that.addSystemMessage(obj.content);
                                 break;
                             case 'addSong':
-								console.log('add', obj);
+                                console.log('add', obj);
                                 that.sendAppEvent('addSong', {
                                     data: obj
                                 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -3453,5 +3453,6 @@
         top: 0%;
         left: 50%;
         transform: translate(calc(-50% - 10px), calc(-50% + 8px));
+        pointer-events: none;
     }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3459,5 +3459,6 @@
         top: 0%;
         left: 50%;
         transform: translate(calc(-50% - 10px), calc(-50% + 8px));
+        pointer-events: none;
     }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -329,7 +329,7 @@
                     <MySetting class="bbbug_frame_box" v-if="dialog && dialog.MySetting"></MySetting>
                     <MySongList class="bbbug_frame_box" v-if="dialog && dialog.MySongList"></MySongList>
                     <OnlineList class="bbbug_frame_box" v-if="dialog && dialog.OnlineList"></OnlineList>
-                    <PlayingSongList class="bbbug_frame_box" v-if="dialog && dialog.PlayingSongList" v-on:listUpdate="onPlayingSongListUpdate"></PlayingSongList>
+                    <PlayingSongList class="bbbug_frame_box" v-if="dialog && dialog.PlayingSongList"></PlayingSongList>
                     <Profile class="bbbug_frame_box" v-if="dialog && dialog.Profile"></Profile>
                     <RoomCreate class="bbbug_frame_box" v-if="dialog && dialog.RoomCreate"></RoomCreate>
                     <RoomList class="bbbug_frame_box" v-if="dialog && dialog.RoomList"></RoomList>
@@ -1393,7 +1393,6 @@
                 playMusic() {
                     let that = this;
                     that.getMusicLrc();
-                    that.getPlayingSongCount();
                     that.audioRetryTimes = 0;
                     that.$nextTick(function () {
                         that.audioStartPlay();
@@ -2260,6 +2259,12 @@
                             that.messageList.shift();
                         }
                         obj.time = parseInt(new Date().valueOf() / 1000);
+
+						// 更新当前歌曲数量
+						if(!isNaN(obj.count)) {
+							that.songCount = obj.count;
+						}
+
                         switch (obj.type) {
                             case 'preload':
                                 that.nextAudioUrl = obj.url;
@@ -2413,6 +2418,7 @@
                                 //     that.addSystemMessage(obj.content);
                                 break;
                             case 'addSong':
+								console.log('add', obj);
                                 that.sendAppEvent('addSong', {
                                     data: obj
                                 });
@@ -2438,9 +2444,6 @@
                                 } else {
                                     that.addSystemMessage(that.urldecode(obj.user.user_name) + " 点了一首 《" + obj.song.name + "》(" + obj.song.singer + ")");
                                 }
-                                this.songCount++;
-                                // 因为存在机器人的歌被替换的情况，用户点歌时更新一下歌曲列表
-                                this.getPlayingSongCount();
                                 break;
                             case 'push':
                                 that.sendAppEvent('pushSong', {
@@ -2453,7 +2456,6 @@
                                 that.sendAppEvent('removeSong', {
                                     data: obj
                                 });
-                                this.songCount--;
                                 that.addSystemMessage(that.urldecode(obj.user.user_name) + " 将歌曲 《" + obj.song.name + "》(" + obj.song.singer + ") 从队列移除");
                                 break;
                             case 'removeban':
@@ -2496,7 +2498,6 @@
                                     data: obj
                                 });
                                 that.addSystemMessage(that.urldecode(obj.user.user_name) + " 切掉了当前播放的歌曲 《" + obj.song.name + "》(" + obj.song.singer + ") ");
-                                this.songCount--;
                                 break;
                             case 'all':
                                 that.addSystemMessage(obj.content, '#fff', '#666');
@@ -2631,32 +2632,6 @@
                     that.websocket.reConnectTimer = setTimeout(function () {
                         that.connectWebsocket();
                     }, 1000);
-                },
-
-                /**
-                 * @description: 获取当前播放的歌曲列表，用于显示图标
-                 * @param {null} 
-                 * @return {null}
-                 */
-                getPlayingSongCount() {
-                    const that = this;
-                    that.request({
-                        url: "song/songList",
-                        data: {
-                            room_id: that.global.room_id
-                        },
-                        success(res) {
-                            that.songCount = res.data && res.data.length || 0;
-                        }
-                    });
-                },
-                /**
-                 * @description: 歌曲列表更新事件
-                 * @param {null}
-                 * @return {null}
-                 */
-                onPlayingSongListUpdate(list) {
-                    this.songCount = list.length;
                 }
             },
         }

--- a/src/components/PlayingSongList.vue
+++ b/src/components/PlayingSongList.vue
@@ -92,7 +92,6 @@
                         success(res) {
                             that.bbbug_loading = false;
                             that.list = res.data;
-                            that.$emit('listUpdate', res.data);
                         },
                         error(res) {
                             that.bbbug_loading = false;


### PR DESCRIPTION
* 修复歌曲数量图标挡住点击事件的bug。
* 移除了所有前端计算当前歌曲数量的逻辑，优化了算法。
* 歌曲数量数据完全来自于任意websocket事件的 `count` 字段，务必在适当时机传入此字段。
> (目前 *[2021-06-10 15:00]* `playSong` 事件未发送`count`， 请确保修复此问题后再merge本PR)。
![79C5A3622A4B2D38F34E08E6612C8175](https://user-images.githubusercontent.com/6663691/121479334-e2484880-ca04-11eb-9283-e8e0b288621d.jpg)
